### PR TITLE
Update regex for new release (2.0) 

### DIFF
--- a/KeePassX/KeePassX.download.recipe
+++ b/KeePassX/KeePassX.download.recipe
@@ -23,7 +23,7 @@
 					<key>url</key>
 					<string>http://www.keepassx.org/downloads/</string>
 					<key>re_pattern</key>
-					<string>(/releases/[0-9].[0-9].[0-9]/KeePassX-[0-9].[0-9].[0-9].dmg)</string>
+					<string>(/releases/[0-9\.]+/KeePassX-[0-9\.]+.dmg)</string>
 					<key>result_output_var_name</key>
 					<string>url</string>
 				</dict>


### PR DESCRIPTION
KeepassX 2.0 was released yesterday (2015-12-07) and has moved from a three part version number (X.Y.Z) to a 2 part version number (A.B).

The download recipe seems to have been broken because of this as it is expecting the version numbers in the URLs to match X.Y.X. 

This quick (and somewhat dirty) change makes the regular expression for matching the version not  rely on a particular number of parts to the version number.
