### PR TITLE
Change Visual Studio Code link and add CodeSigVerifier

### DIFF
--- a/Visual Studio Code/VisualStudioCode.download.recipe
+++ b/Visual Studio Code/VisualStudioCode.download.recipe
@@ -15,26 +15,13 @@
 		<string>0.6.1</string>
 		<key>Process</key>
 		<array>
-			<!--Sadly GitHubReleasesInfoProvider gives back - Error: No releases found for repo 'Microsoft/vscode'
-			<dict>
-                    <key>Processor</key>
-                    <string>GitHubReleasesInfoProvider</string>
-                    <key>Arguments</key>
-                    <dict>
-												<key>sort_by_highest_tag_names</key>
-												<true/>
-                        <key>github_repo</key>
-                        <string>Microsoft/vscode</string>
-                    </dict>
-        </dict>-->
 			<dict>
 				<key>Processor</key>
-				<string>CURLDownloader</string>
+				<string>URLDownloader</string>
 				<key>Arguments</key>
 				<dict>
 					<key>url</key>
-					<string>https://az764295.vo.msecnd.net/stable/66f37fd2a99eb9d628dd374d81d78835b410c39b/VSCode-darwin-stable.zip</string>
-					<!--<string>%url%</string>-->
+					<string>https://go.microsoft.com/fwlink/?LinkID=620882</string>
 					<key>filename</key>
 					<string>vscode.zip</string>
 				</dict>
@@ -42,6 +29,30 @@
 			<dict>
 				<key>Processor</key>
 				<string>EndOfCheckPhase</string>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>Unarchiver</string>
+				<key>Arguments</key>
+				<dict>
+					<key>archive_path</key>
+					<string>%pathname%</string>
+					<key>destination_path</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<key>purge_destination</key>
+					<true/>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>CodeSignatureVerifier</string>
+				<key>Arguments</key>
+				<dict>
+					<key>input_path</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%/Visual Studio Code.app</string>
+					<key>requirement</key> 
+					<string>identifier "com.microsoft.VSCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
+				</dict>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
Fixes #9 

```
$ autopkg run Visual\ Studio\ Code/VisualStudioCode.download -v
Processing Visual Studio Code/VisualStudioCode.download...
WARNING: Visual Studio Code/VisualStudioCode.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 12 Sep 2016 13:16:02 GMT
URLDownloader: Storing new ETag header: 0x8D3DB0EF1B77BC8
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.valdore86.download.visualstudiocode/downloads/vscode.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename vscode.zip
Unarchiver: Unarchived /Users/cwhits/Library/AutoPkg/Cache/com.github.valdore86.download.visualstudiocode/downloads/vscode.zip to /Users/cwhits/Library/AutoPkg/Cache/com.github.valdore86.download.visualstudiocode/Visual Studio Code
CodeSignatureVerifier
CodeSignatureVerifier: Verifying application bundle signature...
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/com.github.valdore86.download.visualstudiocode/Visual Studio Code/Visual Studio Code.app: valid on disk
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/com.github.valdore86.download.visualstudiocode/Visual Studio Code/Visual Studio Code.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/com.github.valdore86.download.visualstudiocode/Visual Studio Code/Visual Studio Code.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.valdore86.download.visualstudiocode/receipts/VisualStudioCode-receipt-20160921-153541.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.valdore86.download.visualstudiocode/downloads/vscode.zip
```
