### PR TITLE
fix download link

### DIFF
--- a/CommanderOne/CommanderOne.download.recipe
+++ b/CommanderOne/CommanderOne.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>CommanderOne</string>
 		<key>URL</key>
-		<string>https://mac.eltima.com/download/commander.dmg</string>
+		<string>https://cdn.electronic.us/products/commander/mac/download/commander.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.4</string>


### PR DESCRIPTION
Change download link to https://cdn.electronic.us/products/commander/mac/download/commander.dmg
as suggested in CommanderOne recipe issue #22