### PR TITLE
Update MicrosoftRemoteDesktop.munki.recipe

### DIFF
--- a/MicrosoftRemoteDesktop/MicrosoftRemoteDesktop.munki.recipe
+++ b/MicrosoftRemoteDesktop/MicrosoftRemoteDesktop.munki.recipe
@@ -31,6 +31,8 @@
 			<string>With the Microsoft Remote Desktop app, you can connect to a remote PC and your work resources from almost anywhere. Experience the power of Windows with RemoteFX in a Remote Desktop client designed to help you get your work done wherever you are.</string>
 			<key>developer</key>
 			<string>Microsoft</string>
+			<key>minimum_os_version</key>
+            		<string>10.13</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>postinstall_script</key>


### PR DESCRIPTION
Microsoft Remote Desktop 10.4.0 now requires at least macOS version 10.13:

https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/mac-whatsnew
https://apps.apple.com/app/microsoft-remote-desktop/id1295203466