### PR TITLE
Update AWSCLI.munki.recipe

### DIFF
--- a/AWSCLI/AWSCLI.md
+++ b/AWSCLI/AWSCLI.md
@@ -1,0 +1,15 @@
+##Upgrading from AWSCLI to AWSCLI2
+
+If you're upgrading your machines from AWSCLI to AWSCLIV2 please add the following to your override.
+For a regular install there is no need to add this.
+
+```xml
+<key>preinstall_script</key>
+<string>#!/bin/sh
+
+sudo rm -rf /usr/local/aws
+sudo rm /usr/local/bin/aws
+
+exit 0
+</string>
+```

--- a/AWSCLI/AWSCLI.munki.recipe
+++ b/AWSCLI/AWSCLI.munki.recipe
@@ -31,8 +31,9 @@
             <key>preinstall_script</key>
 			<string>#!/bin/sh
 
-sudo rm -rf /usr/local/aws
+sudo rm -rf /usr/local/aws-cli
 sudo rm /usr/local/bin/aws
+sudo rm /usr/local/bin/aws_completer
 
 exit 0
 			</string>

--- a/AWSCLI/AWSCLI.munki.recipe
+++ b/AWSCLI/AWSCLI.munki.recipe
@@ -28,15 +28,6 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
-            <key>preinstall_script</key>
-			<string>#!/bin/sh
-
-sudo rm -rf /usr/local/aws-cli
-sudo rm /usr/local/bin/aws
-sudo rm /usr/local/bin/aws_completer
-
-exit 0
-			</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
Referenced: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-mac.html

I'm not completely clear the need for this preinstall_script, but I suspect it its because newer versions don't upgrade well and it's easier/cleaner to start fresh? Maybe you can shed some light on that.

Also, would it make sense to run `sudo pkgutil --forget com.amazon.aws.cli2` in the preinstall_script as well?