### PR TITLE
add deprecationwarning

### DIFF
--- a/Harvest/Harvest.download.recipe
+++ b/Harvest/Harvest.download.recipe
@@ -6,6 +6,10 @@
 	<string>Downloads the current release version of Harvest via appcast.</string>
 	<key>Identifier</key>
 	<string>com.github.valdore86.download.harvest</string>
+	<key>DeprecationWarning</key>
+	<string>The recipes for Harvest will be decommissioned at the end of April.
+	Harvest has only been updating their MAS app since a recent update.
+	Please take a look at https://github.com/autopkg/nmcspadden-recipes/tree/master/AppStoreApp</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/Harvest/Harvest.munki.recipe
+++ b/Harvest/Harvest.munki.recipe
@@ -6,6 +6,10 @@
 	<string>Downloads the current release version of Harvest via appcast and imports it into a Munki repository.</string>
 	<key>Identifier</key>
 	<string>com.github.valdore86.munki.harvest</string>
+	<key>DeprecationWarning</key>
+	<string>These recipes for Harvest will be decommissioned at the end of April.
+	Harvest has only been updating their MAS app since a recent update.
+	Please take a look at https://github.com/autopkg/nmcspadden-recipes/tree/master/AppStoreApp on how to use these with AutoPkg.</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>


### PR DESCRIPTION
These recipes for Harvest will be decommissioned at the end of April.
Harvest has only been updating their MAS app since a recent update.
Please take a look at https://github.com/autopkg/nmcspadden-recipes/tree/master/AppStoreApp on how to use these with AutoPkg.