### PR TITLE
Deprecate KeePassX recipes

### DIFF
--- a/KeePassX/KeePassX.download.recipe
+++ b/KeePassX/KeePassX.download.recipe
@@ -12,9 +12,18 @@
 		<string>KeePassX</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.4</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the KeePassX recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
In order to simplify AutoPkg recipe search results, this PR deprecates the KeePassX recipes, which are redundant with the ones in my homebysix-recipes repo.
