### PR TITLE
Cleanup temp app bundle and DMG for VS Code recipe

### DIFF
--- a/Visual Studio Code/VisualStudioCode.munki.recipe
+++ b/Visual Studio Code/VisualStudioCode.munki.recipe
@@ -58,6 +58,18 @@
 			<key>Processor</key>
 			<string>MunkiImporter</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi there 👋

The **Visual Studio Code** recipe leaves a residual app bundle + DMG around, so this PR attempts to cleanup files that are no longer required.

Should save approximately **600MB** of disk space!